### PR TITLE
fix ruby package for lualatex

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -7,7 +7,7 @@
 \usepackage{luatexja-otf}
 \usepackage{graphicx}
 \usepackage{setspace}
-\usepackage{pxrubrica}
+\usepackage{luatexja-ruby}
 \usepackage[x-1a]{pdfx}
 
 % documentinfomation


### PR DESCRIPTION
In LuaLaTeX, we should use `luatexja-ruby` package for ruby. `px` package series are for pLaTeX.